### PR TITLE
Prevent duplicate GUI startup

### DIFF
--- a/src/cvd/utils/container.py
+++ b/src/cvd/utils/container.py
@@ -50,6 +50,7 @@ class ApplicationContainer:
         default_factory=list
     )
     _shutdown_requested: bool = field(default=False)
+    _started: bool = field(default=False)
 
     @classmethod
     def create(cls, config_dir: Path) -> "ApplicationContainer":
@@ -140,6 +141,9 @@ class ApplicationContainer:
     async def startup(self) -> None:
         """Async startup for all services"""
         try:
+            if self._started:
+                return
+            self._started = True
             info("Starting CVD Tracker services...")
 
             # Initialize web application
@@ -172,7 +176,7 @@ class ApplicationContainer:
 
             @app.on_startup
             async def _startup() -> None:
-                await self.web_application.startup()
+                await self.startup()
 
             @app.on_shutdown
             async def _shutdown() -> None:


### PR DESCRIPTION
## Summary
- ensure ApplicationContainer.startup only runs once
- call container.startup from the NiceGUI entry

## Testing
- `pytest tests/test_async_utils.py::test_run_with_timeout_expires -q`
- `pytest tests/test_data_saver_flush_interval.py::test_default_flush_interval -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_6859718d2b908333bcdb72a2ba5e7cbf