### PR TITLE
Handle empty motion status

### DIFF
--- a/src/cvd/gui/alt_gui_elements/motion_detection_element.py
+++ b/src/cvd/gui/alt_gui_elements/motion_detection_element.py
@@ -121,7 +121,16 @@ class MotionStatusSection:
     def _refresh_status(self) -> None:
         """Update display labels with current motion detection results"""
         result = self._get_result()
-        if not result:
+        if result is None:
+            # Clear status when no result is available
+            self.motion_detected = False
+            self.motion_icon.name = "motion_photos_off"
+            self.motion_icon.classes(replace="text-gray-500")
+            self.motion_label.text = "No Motion Detected"
+            self.motion_percentage.text = "Motion Level: 0%"
+            self.confidence_label.text = "Confidence: --"
+            if self._update_callback:
+                self._update_callback(False)
             return
 
         # remember previous detection state before updating
@@ -142,7 +151,6 @@ class MotionStatusSection:
 
         # update last motion time and count only on rising edge
         if result.motion_detected and not prev:
-
             self._last_motion_time = datetime.now()
             self._detection_count += 1
 


### PR DESCRIPTION
## Summary
- handle missing motion detection results
- ensure header motion icon resets when data disappears
- test motion status reset when results vanish

## Testing
- `pre-commit run --files src/cvd/gui/alt_gui_elements/motion_detection_element.py tests/test_alt_gui.py`
- `pytest -q` *(fails: 69 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6859b7a63a9083339c6145da1751026f