### PR TITLE
Add camera access check with unit test

### DIFF
--- a/src/cvd/gui/alt_application.py
+++ b/src/cvd/gui/alt_application.py
@@ -1446,6 +1446,13 @@ class SimpleGUIApplication:
             self.webcam_stream.update_resolutions(self.supported_camera_modes)
             await self.scan_cameras()
 
+        if self.camera_controller is not None:
+            accessible = await self.camera_controller.test_camera_access()
+            if not accessible:
+                ui.notify("Camera access failed", type="warning")
+                warning("Camera access test failed")
+                return
+
         success = await self.controller_manager.start_all_controllers()
 
         if success:


### PR DESCRIPTION
## Summary
- add `CameraCaptureController.test_camera_access`
- verify camera access during `SimpleGUIApplication.startup`
- test startup abort when camera access fails

## Testing
- `pytest tests/test_simple_gui_application.py -q`
- `PYTHONPATH=. pytest -q` *(fails: 36 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6859cc5713588333a5574133ada6d7a9