### PR TITLE
Improve TUHH email validation

### DIFF
--- a/src/cvd/gui/alt_gui_elements/alert_element.py
+++ b/src/cvd/gui/alt_gui_elements/alert_element.py
@@ -16,6 +16,9 @@ import json
 from datetime import datetime
 import re
 
+# Pattern allowing common characters in local part and enforcing @tuhh.de domain
+TUHH_EMAIL_PATTERN = re.compile(r"^[A-Za-z0-9._+-]+@tuhh\.de$")
+
 
 class EmailAlertWizard:
     """4-Step Email Alert Service Setup Wizard using NiceGUI Stepper.
@@ -485,16 +488,11 @@ class EmailAlertWizard:
             add_email_btn.disable()
 
     def _is_valid_email(self, email: str) -> bool:
-        """Check if email ends with @tuhh.de regardless of local part."""
+        """Return ``True`` if the email matches :data:`TUHH_EMAIL_PATTERN`."""
         if not email:
             return False
 
-        try:
-            local, domain = email.strip().rsplit("@", 1)
-        except ValueError:
-            return False
-
-        return bool(local) and domain == "tuhh.de"
+        return TUHH_EMAIL_PATTERN.fullmatch(email) is not None
 
 
     def _add_email(

--- a/src/cvd/gui/alt_gui_elements/alert_element_new.py
+++ b/src/cvd/gui/alt_gui_elements/alert_element_new.py
@@ -1,0 +1,7 @@
+"""Compatibility shim for :mod:`alert_element`.
+
+This module re-exports all public symbols from :mod:`alert_element` so that
+imports of ``alert_element_new`` continue to work.
+"""
+
+from .alert_element import *  # noqa: F401,F403

--- a/tests/test_email_alert_wizard_validation.py
+++ b/tests/test_email_alert_wizard_validation.py
@@ -42,12 +42,26 @@ def dummy_ui(monkeypatch):
 
 def test_is_valid_email_tuhh_domain_only():
     wizard = EmailAlertWizard()
-    assert wizard._is_valid_email("user@tuhh.de")
-    assert wizard._is_valid_email("test.user@tuhh.de")
-    assert wizard._is_valid_email("foo+bar-baz@tuhh.de")
-    assert not wizard._is_valid_email("user@example.com")
-    assert not wizard._is_valid_email("user@tuhh.com")
-    assert not wizard._is_valid_email("invalid")
+    valid_emails = [
+        "user@tuhh.de",
+        "test.user@tuhh.de",
+        "foo+bar-baz@tuhh.de",
+        "a_b-c.d+e@tuhh.de",
+        "123@tuhh.de",
+    ]
+    invalid_emails = [
+        "user@example.com",
+        "user@tuhh.com",
+        "invalid",
+        "bad!char@tuhh.de",
+        "user@tuhh.de ",
+        " user@tuhh.de",
+    ]
+
+    for addr in valid_emails:
+        assert wizard._is_valid_email(addr)
+    for addr in invalid_emails:
+        assert not wizard._is_valid_email(addr)
 
 
 def test_remove_last_recipient_disables_next(dummy_ui):


### PR DESCRIPTION
## Summary
- add regex for TUHH email addresses
- validate emails against the regex in `_is_valid_email`
- expose old `alert_element_new` as compatibility shim
- expand email validation tests with more valid/invalid samples

## Testing
- `pytest -q tests/test_email_alert_wizard_validation.py::test_is_valid_email_tuhh_domain_only -vv`
- `pytest -q tests/test_email_alert_wizard_validation.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_6859d2162e048333a5ede34b335013f6